### PR TITLE
add Dockerfile for Android 26 sdk

### DIFF
--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -4,10 +4,16 @@ MAINTAINER Maychell Oliveira <maychell.oliveira@codeminer42.com>
 # Android SDK
 ENV ANDROID_HOME /srv/var/android-sdk
 
-# Install required tools
-RUN apt-get --quiet update --yes \
-    && apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1 --no-install-recommends \
-    && apt-get install libqt5widgets5 --yes
+# Install dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      wget \
+      tar \
+      unzip \
+      lib32stdc++6 \
+      lib32z1 \
+      libqt5widgets5 \
+      libqt5svg5
 
 # Install Android SDK tools into ${ANDROID_HOME}
 RUN mkdir -p ${ANDROID_HOME}
@@ -21,29 +27,19 @@ RUN wget --quiet --output-document=android-sdk.zip https://dl.google.com/android
 RUN mkdir -p ${ANDROID_HOME}/licenses \
     && echo 8933bad161af4178b1185d1a37fbf41ea5269c55 > ${ANDROID_HOME}/licenses/android-sdk-license
 
-# Install platform tools
+# Install Android SDK packages
 RUN ln -s ${ANDROID_HOME}/tools/bin/sdkmanager /usr/bin/sdkmanager \
-    && sdkmanager "platform-tools"
-
-# Emulator
-ENV EMULATOR_HOME /srv/var
-# Download emulator
-RUN wget https://dl.google.com/android/repository/emulator-linux-4077558.zip -O emulator.zip \
-    && unzip -q emulator.zip -d ${EMULATOR_HOME} \
-    && rm -f emulator.zip
+    && yes | sdkmanager \
+        "platform-tools" \
+        "platforms;android-26" \
+        "build-tools;26.0.2" \
+        "emulator" \
+        "system-images;android-26;google_apis;x86"
 
 # Create a virtual device
-RUN ln -s ${EMULATOR_HOME}/emulator/emulator64-x86 /usr/bin/emulator64-x86 \
+RUN ln -s ${EMULATOR_HOME}/emulator/emulator /usr/bin/emulator \
     && ln -s ${ANDROID_HOME}/tools/bin/avdmanager /usr/bin/avdmanager
-
-# SDKs
-# Please keep these in descending order!
-RUN echo y | sdkmanager \
-    "platforms;android-26" \
-    "build-tools;26.0.2"
-
-RUN echo y | sdkmanager "system-images;android-26;google_apis;x86"
 
 RUN echo no | avdmanager create avd -n androidAVD --abi google_apis/x86 --package 'system-images;android-26;google_apis;x86'
 
-RUN emulator64-x86 -avd androidAVD -no-window -no-audio &
+#RUN emulator64-x86 -avd androidAVD -no-window -no-audio &

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -6,7 +6,8 @@ ENV ANDROID_HOME /srv/var/android-sdk
 
 # Install required tools
 RUN apt-get --quiet update --yes \
-    && apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1 --no-install-recommends
+    && apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1 --no-install-recommends \
+    && apt-get install libqt5widgets5 --yes
 
 # Install Android SDK tools into ${ANDROID_HOME}
 RUN mkdir -p ${ANDROID_HOME}
@@ -25,11 +26,15 @@ RUN ln -s ${ANDROID_HOME}/tools/bin/sdkmanager /usr/bin/sdkmanager \
     && sdkmanager "platform-tools"
 
 # Emulator
-ENV EMULATOR_HOME /srv/var/emulator
+ENV EMULATOR_HOME /srv/var
 # Download emulator
 RUN wget https://dl.google.com/android/repository/emulator-linux-4077558.zip -O emulator.zip \
-    && unzip -q emulator.zip -d $EMULATOR_HOME \
+    && unzip -q emulator.zip -d ${EMULATOR_HOME} \
     && rm -f emulator.zip
+
+# Create a virtual device
+RUN ln -s ${EMULATOR_HOME}/emulator/emulator64-x86 /usr/bin/emulator64-x86 \
+    && ln -s ${ANDROID_HOME}/tools/bin/avdmanager /usr/bin/avdmanager
 
 # SDKs
 # Please keep these in descending order!
@@ -37,5 +42,8 @@ RUN echo y | sdkmanager \
     "platforms;android-26" \
     "build-tools;26.0.2"
 
-RUN ln -s ${EMULATOR_HOME}/emulator64-x86 /usr/bin/emulator64-x86 && \
-    emulator64-x86 -avd test -no-window -no-audio &
+RUN echo y | sdkmanager "system-images;android-26;google_apis;x86"
+
+RUN echo no | avdmanager create avd -n androidAVD --abi google_apis/x86 --package 'system-images;android-26;google_apis;x86'
+
+RUN emulator64-x86 -avd androidAVD -no-window -no-audio &

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -1,0 +1,41 @@
+FROM openjdk:8-jdk
+MAINTAINER Maychell Oliveira <maychell.oliveira@codeminer42.com>
+
+# Android SDK
+ENV ANDROID_HOME /srv/var/android-sdk
+
+# Install required tools
+RUN apt-get --quiet update --yes \
+    && apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1 --no-install-recommends
+
+# Install Android SDK tools into ${ANDROID_HOME}
+RUN mkdir -p ${ANDROID_HOME}
+RUN wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \
+    && unzip android-sdk.zip -d ${ANDROID_HOME} \
+    && rm -f android-sdk.zip
+
+# Accept "android-sdk-license" before installing components, no need to echo y for each component
+# License is valid for all the standard components in versions installed from this file
+# Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
+RUN mkdir -p ${ANDROID_HOME}/licenses \
+    && echo 8933bad161af4178b1185d1a37fbf41ea5269c55 > ${ANDROID_HOME}/licenses/android-sdk-license
+
+# Install platform tools
+RUN ln -s ${ANDROID_HOME}/tools/bin/sdkmanager /usr/bin/sdkmanager \
+    && sdkmanager "platform-tools"
+
+# Emulator
+ENV EMULATOR_HOME /srv/var/emulator
+# Download emulator
+RUN wget https://dl.google.com/android/repository/emulator-linux-4077558.zip -O emulator.zip \
+    && unzip -q emulator.zip -d $EMULATOR_HOME \
+    && rm -f emulator.zip
+
+# SDKs
+# Please keep these in descending order!
+RUN echo y | sdkmanager \
+    "platforms;android-26" \
+    "build-tools;26.0.2"
+
+RUN ln -s ${EMULATOR_HOME}/emulator64-x86 /usr/bin/emulator64-x86 && \
+    emulator64-x86 -avd test -no-window -no-audio &

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# docker-ci-android
-Docker Android images used by Gitlab CI
+# Codeminer42 Android Image for CI builds
+
+Docker Android images used by Gitlab CI.
+
+## Dependencies
+
+The following dependencies are being installed on all images:
+
+* Android 26 sdk for linux
+* Android Emulator
+
+## Tags
+
+We currently have images for the following Android versions.
+
+### Android images
+
+- `26`, `latest` [Dockerfile](https://github.com/Codeminer42/docker-ci-android/blob/master/26/Dockerfile)
+
+## Contributing
+
+`Dockerfiles` are stored under folders for each version.
+
+For updating the images, just open a _pull request_ with
+the new `Dockerfile` version and, after accepted, Docker
+Hub will build automatically after a few minutes.
+
+The images should setup an environment that is widely used,
+please don't install dependencies that are specific to a
+project. It's also good to have a pattern and all images
+support the same things.


### PR DESCRIPTION
This pr aims to create a Docker Android 26 image to be used by Gitlab CI.